### PR TITLE
Replaced "libusb" backend specifier with "*" wildcard

### DIFF
--- a/src/bladerf_dev.cpp
+++ b/src/bladerf_dev.cpp
@@ -142,7 +142,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
         else {
 
             /* open bladeRF device */
-            sprintf(buf, "libusb:instance=%d", device_index);
+            sprintf(buf, "*:instance=%d", device_index);
             ret = bladerf_open(&_devices[device_index], buf);
             if (ret < 0) {
                 sprintf(errmsg," Failed to use bladeRF device #%d.\n",device_index); mexErrMsgTxt(errmsg);

--- a/src/bladerf_sink.cpp
+++ b/src/bladerf_sink.cpp
@@ -189,7 +189,7 @@ static void mdlStart(SimStruct *S)
     /* give handle to PWork vector */
     ssSetPWorkValue(S, DEVICE, NULL);
 
-    sprintf(instance, "libusb:instance=%d", device_index);
+    sprintf(instance, "*:instance=%d", device_index);
     /* open bladeRF device */
     ret = bladerf_open(&dev, instance);
     if (ret < 0) {

--- a/src/bladerf_source.cpp
+++ b/src/bladerf_source.cpp
@@ -193,7 +193,7 @@ static void mdlStart(SimStruct *S)
     /* give handle to PWork vector */
     ssSetPWorkValue(S, DEVICE, NULL);
 
-    sprintf(instance, "libusb:instance=%d", device_index);
+    sprintf(instance, "*:instance=%d", device_index);
     /* open bladeRF device */
     ret = bladerf_open(&dev, instance);
     if (ret < 0) {


### PR DESCRIPTION
This allows other backends, such as the Cypress backend to be used
by libbladeRF.

Note that in the case where multiple devices are present on different
backends, it is possible for each device to be "instance 0" on each
backend. In the future it might be better to decouple the device ID
number the user provides from the actual instance number passed to the
device.