### PR TITLE
Corrected how to access pointers of complex numbers.

### DIFF
--- a/src/bladerf_sink.cpp
+++ b/src/bladerf_sink.cpp
@@ -261,15 +261,15 @@ static void mdlOutputs(SimStruct *S, int_T tid)
 
     /* get bladeRF object back from PWork vector */
     struct bladerf *dev = (struct bladerf *)ssGetPWorkValue(S, DEVICE);
-    //uint16_t *ptr;
     int16_t *ptr;
     /* output buffer */
     InputRealPtrsType inPtr = ssGetInputPortRealSignalPtrs(S, 0);
-
-    //ptr = (uint16_t *)malloc(frame_length * 2 * sizeof(uint16_t));
+    
     ptr = (int16_t *)malloc(frame_length * 2 * sizeof(int16_t));
-    for (int k = 0; k < frame_length*2; ++k)
-        ptr[k] = (int16_t)(*inPtr[k] * 2048.0f);
+    for (int k = 0; k < frame_length; ++k) {
+        ptr[2*k]   = (int16_t)(*inPtr[k] * 2048.0f);
+        ptr[2*k+1] = (int16_t)(*(inPtr[k] + 1) * 2048.0f);
+    }
     ret = bladerf_sync_tx(dev, ptr, frame_length, NULL, 500);
 //    if (ret < 0)
 //      ssSetErrorStatusf(S,"Failed to TX with error code %d\n", ret);


### PR DESCRIPTION
Reissued #7

Referred to the following sample program.
C:\Program Files\MATLAB\R2015a\toolbox\simulink\simdemos\simfeatures\src\sfun_cplx.c